### PR TITLE
DD-326 Upgraded parent to be compatible with Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 matrix:
   include:
     - language: java
-      jdk: openjdk8
+      jdk: openjdk11
       cache:
         directories:
           - "$HOME/.m2/repository"

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>6.0.3</version>
+        <version>6.1.1</version>
     </parent>
 
     <groupId>nl.knaw.dans.dd</groupId>


### PR DESCRIPTION
Fixes DD-326

# Description of changes
* Upgraded to parent 6.1.1 so that Java 8 is no longer a yum dependency

# How to test


# Related PRs 
* https://github.com/DANS-KNAW/dd-dtap/pull/70

# Notify
@DANS-KNAW/dataversedans
