### PR TITLE
DD-358. Find out why workflow fails for non admin users

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-dataverse-scala-lib_2.12</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
 
         <!-- Apache Commons -->


### PR DESCRIPTION
Fixes DD-358

# Description of changes
* Upgrade to version 1.2.2 of `dans-dataverse-scala-lib`. This version of the lib no longer sends the API token if a workflowID is present.

# How to test
* Create and publish a dataset via de UI with a different user than dataverseAdmin.
* Check that Data Vault Metadata is correctly created.


# Notify
@DANS-KNAW/dataversedans
