### PR TITLE
implemented paused state check for resume call

### DIFF
--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -18,6 +18,12 @@ dataverse.api-key=
 dataverse.await-lock-max-retries=30
 dataverse.await-lock-wait-time-ms=500
 
+#
+# How long to wait for the workflow to get paused before the resume call can be made.
+#
+dataverse.await-workflow-paused-max-retries=30
+dataverse.await-workflow-paused-time-ms=500
+
 
 
 pid-generator.base-url=http://localhost:20140/

--- a/src/main/scala/nl.knaw.dans.dd.prepub/Configuration.scala
+++ b/src/main/scala/nl.knaw.dans.dd.prepub/Configuration.scala
@@ -26,8 +26,8 @@ case class Configuration(version: String,
                          serverPort: Int,
                          pidGeneratorBaseUrl: URI,
                          dataverse: DataverseInstanceConfig,
-                         AwaitWorkflowPausedStateMaxNumberOfRetries: Int,
-                         AwaitWorkflowPausedStateMillisecondsBetweenRetries: Int,
+                         awaitWorkflowPausedStateMaxNumberOfRetries: Int,
+                         awaitWorkflowPausedStateMillisecondsBetweenRetries: Int,
                         )
 
 object Configuration {
@@ -56,8 +56,8 @@ object Configuration {
         awaitLockStateMaxNumberOfRetries = Option(properties.getInt("dataverse.await-lock-max-retries")).getOrElse(10),
         awaitLockStateMillisecondsBetweenRetries = Option(properties.getInt("dataverse.await-lock-wait-time-ms")).getOrElse(1000),
       ),
-      AwaitWorkflowPausedStateMaxNumberOfRetries = properties.getInt("dataverse.await-workflow-paused-max-retries"),
-      AwaitWorkflowPausedStateMillisecondsBetweenRetries = properties.getInt("dataverse.await-workflow-paused-time-ms")
+      awaitWorkflowPausedStateMaxNumberOfRetries = properties.getInt("dataverse.await-workflow-paused-max-retries"),
+      awaitWorkflowPausedStateMillisecondsBetweenRetries = properties.getInt("dataverse.await-workflow-paused-time-ms")
     )
   }
 }

--- a/src/main/scala/nl.knaw.dans.dd.prepub/Configuration.scala
+++ b/src/main/scala/nl.knaw.dans.dd.prepub/Configuration.scala
@@ -15,17 +15,19 @@
  */
 package nl.knaw.dans.dd.prepub
 
-import java.net.URI
-
 import better.files.File
 import better.files.File.root
 import nl.knaw.dans.lib.dataverse.DataverseInstanceConfig
 import org.apache.commons.configuration.PropertiesConfiguration
 
+import java.net.URI
+
 case class Configuration(version: String,
                          serverPort: Int,
                          pidGeneratorBaseUrl: URI,
-                         dataverse: DataverseInstanceConfig
+                         dataverse: DataverseInstanceConfig,
+                         AwaitWorkflowPausedStateMaxNumberOfRetries: Int,
+                         AwaitWorkflowPausedStateMillisecondsBetweenRetries: Int,
                         )
 
 object Configuration {
@@ -53,7 +55,10 @@ object Configuration {
         apiVersion = properties.getString("dataverse.api-version"),
         awaitLockStateMaxNumberOfRetries = Option(properties.getInt("dataverse.await-lock-max-retries")).getOrElse(10),
         awaitLockStateMillisecondsBetweenRetries = Option(properties.getInt("dataverse.await-lock-wait-time-ms")).getOrElse(1000),
-      ))
+      ),
+      AwaitWorkflowPausedStateMaxNumberOfRetries = properties.getInt("dataverse.await-workflow-paused-max-retries"),
+      AwaitWorkflowPausedStateMillisecondsBetweenRetries = properties.getInt("dataverse.await-workflow-paused-time-ms")
+    )
   }
 }
 

--- a/src/main/scala/nl.knaw.dans.dd.prepub/PrePublishWorkflowApp.scala
+++ b/src/main/scala/nl.knaw.dans.dd.prepub/PrePublishWorkflowApp.scala
@@ -35,6 +35,6 @@ class PrePublishWorkflowApp(configuration: Configuration) extends DebugEnhancedL
   }
 
   def scheduleVaultMetadataTask(workFlowVariables: WorkFlowVariables): Try[Unit] = {
-    tasks.add(new SetVaultMetadataTask(workFlowVariables, dataverse, mapper))
+    tasks.add(new SetVaultMetadataTask(workFlowVariables, dataverse, mapper, configuration.AwaitWorkflowPausedStateMaxNumberOfRetries, configuration.AwaitWorkflowPausedStateMillisecondsBetweenRetries))
   }
 }

--- a/src/main/scala/nl.knaw.dans.dd.prepub/PrePublishWorkflowApp.scala
+++ b/src/main/scala/nl.knaw.dans.dd.prepub/PrePublishWorkflowApp.scala
@@ -35,6 +35,6 @@ class PrePublishWorkflowApp(configuration: Configuration) extends DebugEnhancedL
   }
 
   def scheduleVaultMetadataTask(workFlowVariables: WorkFlowVariables): Try[Unit] = {
-    tasks.add(new SetVaultMetadataTask(workFlowVariables, dataverse, mapper, configuration.AwaitWorkflowPausedStateMaxNumberOfRetries, configuration.AwaitWorkflowPausedStateMillisecondsBetweenRetries))
+    tasks.add(new SetVaultMetadataTask(workFlowVariables, dataverse, mapper, configuration.awaitWorkflowPausedStateMaxNumberOfRetries, configuration.awaitWorkflowPausedStateMillisecondsBetweenRetries))
   }
 }

--- a/src/main/scala/nl.knaw.dans.dd.prepub/package.scala
+++ b/src/main/scala/nl.knaw.dans.dd.prepub/package.scala
@@ -29,6 +29,7 @@ package object prepub {
   case class LockStatusMessage(status: String, data: List[LockRecord])
   case class RequestFailedException(status: Int, msg: String, body: String) extends Exception(s"Command could not be executed. Server returned: status line: '$msg', body: '$body'")
   case class ExternalSystemCallException(msg: String, cause: Throwable) extends RuntimeException(msg, cause)
+  case class InvocationIdNotFoundException(numberOfTimesTried: Int, waitTimeInMilliseconds: Int) extends RuntimeException(s"Workflow was not paused. Number of tries = $numberOfTimesTried, wait time between tries = $waitTimeInMilliseconds ms.")
 
   type JsonObject = Map[String, MetadataField]
 
@@ -62,7 +63,5 @@ package object prepub {
     case null => JNull
   }
   ))
-
-  case class WorkflowNotPausedException(numberOfTimesTried: Int, waitTimeInMilliseconds: Int) extends RuntimeException(s"Workflow was not paused. Number of tries = $numberOfTimesTried, wait time between tries = $waitTimeInMilliseconds ms.")
 
 }

--- a/src/main/scala/nl.knaw.dans.dd.prepub/package.scala
+++ b/src/main/scala/nl.knaw.dans.dd.prepub/package.scala
@@ -63,4 +63,6 @@ package object prepub {
   }
   ))
 
+  case class WorkflowNotPausedException(numberOfTimesTried: Int, waitTimeInMilliseconds: Int) extends RuntimeException(s"Workflow was not paused. Number of tries = $numberOfTimesTried, wait time between tries = $waitTimeInMilliseconds ms.")
+
 }

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -19,4 +19,10 @@ dataverse.api-key=
 dataverse.await-lock-max-retries=30
 dataverse.await-lock-wait-time-ms=500
 
+#
+# How long to wait for the workflow to get paused before the resume call can be made.
+#
+dataverse.await-workflow-paused-max-retries=10
+dataverse.await-workflow-paused-time-ms=500
+
 pid-generator.base-url=http://localhost:20140/

--- a/src/test/scala/nl.knaw.dans.dd.prepub/ReadmeSpec.scala
+++ b/src/test/scala/nl.knaw.dans.dd.prepub/ReadmeSpec.scala
@@ -28,7 +28,9 @@ class ReadmeSpec extends AnyFlatSpec with Matchers with CustomMatchers {
     version = "my-version",
     serverPort = 12345,
     pidGeneratorBaseUrl = new URI("http://dummy"),
-    dataverse = null
+    dataverse = null,
+    AwaitWorkflowPausedStateMaxNumberOfRetries = 0,
+    AwaitWorkflowPausedStateMillisecondsBetweenRetries = 0
   )
 
   private val clo = new CommandLineOptions(Array[String](), configuration) {

--- a/src/test/scala/nl.knaw.dans.dd.prepub/ReadmeSpec.scala
+++ b/src/test/scala/nl.knaw.dans.dd.prepub/ReadmeSpec.scala
@@ -29,8 +29,8 @@ class ReadmeSpec extends AnyFlatSpec with Matchers with CustomMatchers {
     serverPort = 12345,
     pidGeneratorBaseUrl = new URI("http://dummy"),
     dataverse = null,
-    AwaitWorkflowPausedStateMaxNumberOfRetries = 0,
-    AwaitWorkflowPausedStateMillisecondsBetweenRetries = 0
+    awaitWorkflowPausedStateMaxNumberOfRetries = 0,
+    awaitWorkflowPausedStateMillisecondsBetweenRetries = 0
   )
 
   private val clo = new CommandLineOptions(Array[String](), configuration) {


### PR DESCRIPTION
Fixes DD-366

# Description of changes
Checks the response of the resume call to see if the workflow has been paused in Dataverse.

# How to test

- Create and publish dataset
- Check log for success: `vagrant ssh` `tail -f /var/opt/dans.knaw.nl/log/dd-pre-publish-workflow/dd-pre-publish-workflow.log`
- In `SetVaultMetadataTask.scala` add `notPausedError=true` on line 67.  Redeploy and publish again. Check log.
- Also, replace `dataverse.workflows().resume(invocationId)` on line 65 with fake response. Redeploy, publish and check the log.

# Related PRs 
(Add links)
* 

# Notify
@DANS-KNAW/dataversedans
