### PR TITLE
DD-504. Change NBN-minting to use UUID generator instead of easy-pid-generator

### DIFF
--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -24,4 +24,7 @@ dataverse.await-lock-wait-time-ms=500
 dataverse.await-workflow-paused-max-retries=30
 dataverse.await-workflow-paused-time-ms=500
 
+#
+# Set this to an NBN namespace that your organization is allowed to mint NBNs in.
+#
 nbn.prefix=nl:ui:13-

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -24,6 +24,4 @@ dataverse.await-lock-wait-time-ms=500
 dataverse.await-workflow-paused-max-retries=30
 dataverse.await-workflow-paused-time-ms=500
 
-
-
-pid-generator.base-url=http://localhost:20140/
+nbn.prefix=nl:ui:13-

--- a/src/main/scala/nl.knaw.dans.dd.prepub/Configuration.scala
+++ b/src/main/scala/nl.knaw.dans.dd.prepub/Configuration.scala
@@ -24,7 +24,7 @@ import java.net.URI
 
 case class Configuration(version: String,
                          serverPort: Int,
-                         pidGeneratorBaseUrl: URI,
+                         nbnPrefix: String,
                          dataverse: DataverseInstanceConfig,
                          awaitWorkflowPausedStateMaxNumberOfRetries: Int,
                          awaitWorkflowPausedStateMillisecondsBetweenRetries: Int,
@@ -46,7 +46,7 @@ object Configuration {
     new Configuration(
       version = (home / "bin" / "version").contentAsString.stripLineEnd,
       serverPort = properties.getInt("daemon.http.port"),
-      pidGeneratorBaseUrl = new URI(properties.getString("pid-generator.base-url") + "/"),
+      nbnPrefix = properties.getString("nbn.prefix"),
       dataverse = DataverseInstanceConfig(
         baseUrl = new URI(properties.getString("dataverse.base-url")),
         apiToken = properties.getString("dataverse.api-key"),

--- a/src/main/scala/nl.knaw.dans.dd.prepub/PrePublishWorkflowApp.scala
+++ b/src/main/scala/nl.knaw.dans.dd.prepub/PrePublishWorkflowApp.scala
@@ -23,7 +23,7 @@ import scala.util.Try
 
 class PrePublishWorkflowApp(configuration: Configuration) extends DebugEnhancedLogging {
   private val dataverse = new DataverseInstance(configuration.dataverse)
-  private val mapper = new DansDataVaultMetadataBlockMapper(configuration.pidGeneratorBaseUrl, dataverse)
+  private val mapper = new DansDataVaultMetadataBlockMapper(configuration.nbnPrefix, dataverse)
   private val tasks = new ActiveTaskQueue[WorkFlowVariables]()
 
   def start(): Try[Unit] = {

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -10,7 +10,7 @@ dataverse.base-url=
 dataverse.api-version=1
 dataverse.connection-timeout-ms=10000
 dataverse.read-timeout-ms=30000
-# TODO: API key should be connected to user that is doing the request
+# TODO: API key should not be necessary anymore
 dataverse.api-key=
 
 #
@@ -25,4 +25,4 @@ dataverse.await-lock-wait-time-ms=500
 dataverse.await-workflow-paused-max-retries=10
 dataverse.await-workflow-paused-time-ms=500
 
-pid-generator.base-url=http://localhost:20140/
+nbn.prefix=nl:ui:13-

--- a/src/test/scala/nl.knaw.dans.dd.prepub/ReadmeSpec.scala
+++ b/src/test/scala/nl.knaw.dans.dd.prepub/ReadmeSpec.scala
@@ -27,7 +27,7 @@ class ReadmeSpec extends AnyFlatSpec with Matchers with CustomMatchers {
   private val configuration = Configuration(
     version = "my-version",
     serverPort = 12345,
-    pidGeneratorBaseUrl = new URI("http://dummy"),
+    nbnPrefix = "nl:ui:13-",
     dataverse = null,
     awaitWorkflowPausedStateMaxNumberOfRetries = 0,
     awaitWorkflowPausedStateMillisecondsBetweenRetries = 0


### PR DESCRIPTION
Fixes DD-504

# Description of changes
* Added a setting for the `nbn.prefix`
* Removed any references to `easy-pid-generator`.
* Changed the minting process to use `UUID.randomUUID()` instead.


# How to test


# Related PRs 
*  https://github.com/DANS-KNAW/dd-dtap/pull/117

# Notify
@DANS-KNAW/dataversedans
